### PR TITLE
sudo not found in docker image at runtime

### DIFF
--- a/src/SnorterDock/Dockerfile
+++ b/src/SnorterDock/Dockerfile
@@ -8,6 +8,7 @@ ENV INTERFACE
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl wget
 RUN git clone https://github.com/joanbono/Snorter.git /opt/Snorter
+RUN sed -i "s/sudo //g" /opt/Snorter/src/Snorter.sh
 RUN /opt/Snorter/src/Snorter.sh -o ${OINKCODE} -i ${INTERFACE}
 USER root
 WORKDIR /opt/Snorter


### PR DESCRIPTION
strip out references to sudo from script... was getting sudo not found errors after having a look why docker build failed