### PR TITLE
Fix to "/opt/Snorter/src/Snorter.sh: Permission denied" error

### DIFF
--- a/src/SnorterDock/Dockerfile
+++ b/src/SnorterDock/Dockerfile
@@ -9,7 +9,7 @@ ENV INTERFACE
 RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl wget
 RUN git clone https://github.com/joanbono/Snorter.git /opt/Snorter
 RUN sed -i "s/sudo //g" /opt/Snorter/src/Snorter.sh
-RUN chmod+x /opt/Snorter/src/Snorter.sh
+RUN chmod +x /opt/Snorter/src/Snorter.sh
 RUN /opt/Snorter/src/Snorter.sh -o ${OINKCODE} -i ${INTERFACE}
 USER root
 WORKDIR /opt/Snorter

--- a/src/SnorterDock/Dockerfile
+++ b/src/SnorterDock/Dockerfile
@@ -9,6 +9,7 @@ ENV INTERFACE
 RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl wget
 RUN git clone https://github.com/joanbono/Snorter.git /opt/Snorter
 RUN sed -i "s/sudo //g" /opt/Snorter/src/Snorter.sh
+RUN chmod+x /opt/Snorter/src/Snorter.sh
 RUN /opt/Snorter/src/Snorter.sh -o ${OINKCODE} -i ${INTERFACE}
 USER root
 WORKDIR /opt/Snorter


### PR DESCRIPTION
This fixes the following error:

/home/user/Snorter/src/SnorterDock/:$ docker build .
Sending build context to Docker daemon  2.048kB
Step 1/10 : From debian:latest
 ---> 8626492fecd3
Step 2/10 : MAINTAINER Joan Bono <@joan_bono>
 ---> Using cache
 ---> 8f29eef03e85
Step 3/10 : ENV OINKCODE=6207cc6ff92dd02d5d3777e42f517598cbb34a76
 ---> Using cache
 ---> 5116fc28ed67
Step 4/10 : ENV INTERFACE=eth0
 ---> Using cache
 ---> 26a39163ef7a
Step 5/10 : RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl wget
 ---> Using cache
 ---> 16a9bc1087fd
Step 6/10 : RUN git clone https://github.com/joanbono/Snorter.git /opt/Snorter
 ---> Using cache
 ---> 095f426113d4
Step 7/10 : RUN sed -i "s/sudo //g" /opt/Snorter/src/Snorter.sh
 ---> Using cache
 ---> 99f06b0f06ba
Step 8/10 : RUN /opt/Snorter/src/Snorter.sh -o ${OINKCODE} -i ${INTERFACE}
 ---> Running in 6b5781ae1443
/bin/sh: 1: /opt/Snorter/src/Snorter.sh: Permission denied
The command '/bin/sh -c /opt/Snorter/src/Snorter.sh -o ${OINKCODE} -i ${INTERFACE}' returned a non-zero code: 126